### PR TITLE
CHORE add seller-verification to user model and /items endpoint

### DIFF
--- a/backend/app/controllers/items_controller.rb
+++ b/backend/app/controllers/items_controller.rb
@@ -31,6 +31,7 @@ class ItemsController < ApplicationController
             bio: item.user.bio,
             image: item.user.image || 'https://static.productionready.io/images/smiley-cyrus.jpg',
             following: signed_in? ? current_user.following?(item.user) : false,
+            isVerified: item.user.isVerified
           },
           favorited: signed_in? ? current_user.favorited?(item) : false,
           favorites_count: item.favorites_count || 0

--- a/backend/db/migrate/20230105155129_add_is_verified_to_users.rb
+++ b/backend/db/migrate/20230105155129_add_is_verified_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsVerifiedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :isVerified, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_061614) do
+ActiveRecord::Schema.define(version: 2023_01_05_155129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2021_04_12_061614) do
     t.string "username"
     t.string "image"
     t.text "bio"
+    t.boolean "isVerified", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
Add seller verification to the user model using a DB migration, and return it as part of the return object in the /items API endpoint.